### PR TITLE
Add support for PATCH to partially replace an entity

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -140,6 +140,10 @@ def patch_group(groupname: str, group: GroupUpdate, response: Response):
         if not user_repo.exists(user.username):
             raise HTTPException(422, f"Given user '{user.username}' does not exist: create it first")
 
+    current_group = group_repo.find_one(groupname)
+    if (not current_group.replies and group.replies == []) and (not current_group.checks and group.checks == []):
+        raise HTTPException(422, 'Group must have at least one check or one reply attribute')
+
     group_repo.update(groupname, group)
     response.headers['Location'] = f'{API_URL}/groups/{group.groupname}'
     return group

--- a/src/api.py
+++ b/src/api.py
@@ -1,15 +1,9 @@
 from database import db_connection, db_tables
 from fastapi import FastAPI, APIRouter, Response, HTTPException
 from pydantic import BaseModel
-from pyfreeradius import User, Group, Nas
+from pyfreeradius import User, Group, Nas, UserUpdate, GroupUpdate, NasUpdate
 from pyfreeradius import UserRepository, GroupRepository, NasRepository
 from typing import List
-
-#
-# We want our REST API endpoints to be KISS!
-# Only GET/POST/DELETE methods are implemented; no PUT/PATCH methods.
-# To modify an existing object, first remove it and then recreate it.
-#
 
 # Load the FreeRADIUS repositories
 user_repo = UserRepository(db_connection, db_tables)
@@ -115,8 +109,8 @@ def post_group(group: Group, response: Response):
     response.headers['Location'] = f'{API_URL}/groups/{group.groupname}'
     return group
 
-@router.put('/nas/{nasname}', tags=['nas'], status_code=201, response_model=Nas, responses={**e409_response})
-def put_nas(nasname: str, nas: Nas, response: Response):
+@router.patch('/nas/{nasname}', tags=['nas'], status_code=201, response_model=Nas, responses={**e409_response})
+def patch_nas(nasname: str, nas: NasUpdate, response: Response):
     if not nas_repo.exists(nasname):
         raise HTTPException(404, 'Given NAS does not exist')
 
@@ -124,8 +118,8 @@ def put_nas(nasname: str, nas: Nas, response: Response):
     response.headers['Location'] = f'{API_URL}/nas/{nas.nasname}'
     return nas
 
-@router.put('/users/{username}', tags=['users'], status_code=201, response_model=User, responses={**e409_response})
-def put_user(username: str, user: User, response: Response):
+@router.patch('/users/{username}', tags=['users'], status_code=201, response_model=User, responses={**e409_response})
+def patch_user(username: str, user: UserUpdate, response: Response):
     if not user_repo.exists(username):
         raise HTTPException(404, detail='Given user does not exist')
 
@@ -133,8 +127,8 @@ def put_user(username: str, user: User, response: Response):
     response.headers['Location'] = f'{API_URL}/users/{user.username}'
     return user
 
-@router.put('/groups/{groupname}', tags=['groups'], status_code=201, response_model=Group, responses={**e409_response})
-def put_group(groupname: str, group: Group, response: Response):
+@router.patch('/groups/{groupname}', tags=['groups'], status_code=201, response_model=Group, responses={**e409_response})
+def patch_group(groupname: str, group: GroupUpdate, response: Response):
     if not group_repo.exists(groupname):
         raise HTTPException(404, 'Given group does not exist')
 

--- a/src/api.py
+++ b/src/api.py
@@ -123,6 +123,10 @@ def patch_user(username: str, user: UserUpdate, response: Response):
     if not user_repo.exists(username):
         raise HTTPException(404, detail='Given user does not exist')
 
+    for group in user.groups or []:
+        if not group_repo.exists(group.groupname):
+            raise HTTPException(422, f"Given group '{group.groupname}' does not exist: create it first")
+
     user_repo.update(username, user)
     response.headers['Location'] = f'{API_URL}/users/{user.username}'
     return user
@@ -131,6 +135,10 @@ def patch_user(username: str, user: UserUpdate, response: Response):
 def patch_group(groupname: str, group: GroupUpdate, response: Response):
     if not group_repo.exists(groupname):
         raise HTTPException(404, 'Given group does not exist')
+
+    for user in group.users or []:
+        if not user_repo.exists(user.username):
+            raise HTTPException(422, f"Given user '{user.username}' does not exist: create it first")
 
     group_repo.update(groupname, group)
     response.headers['Location'] = f'{API_URL}/groups/{group.groupname}'

--- a/src/api.py
+++ b/src/api.py
@@ -109,7 +109,7 @@ def post_group(group: Group, response: Response):
     response.headers['Location'] = f'{API_URL}/groups/{group.groupname}'
     return group
 
-@router.patch('/nas/{nasname}', tags=['nas'], status_code=201, response_model=Nas, responses={**e409_response})
+@router.patch('/nas/{nasname}', tags=['nas'], status_code=200, response_model=Nas, responses={**e409_response})
 def patch_nas(nasname: str, nas: NasUpdate, response: Response):
     if not nas_repo.exists(nasname):
         raise HTTPException(404, 'Given NAS does not exist')
@@ -118,7 +118,7 @@ def patch_nas(nasname: str, nas: NasUpdate, response: Response):
     response.headers['Location'] = f'{API_URL}/nas/{nas.nasname}'
     return nas
 
-@router.patch('/users/{username}', tags=['users'], status_code=201, response_model=User, responses={**e409_response})
+@router.patch('/users/{username}', tags=['users'], status_code=200, response_model=User, responses={**e409_response})
 def patch_user(username: str, user: UserUpdate, response: Response):
     if not user_repo.exists(username):
         raise HTTPException(404, detail='Given user does not exist')
@@ -127,7 +127,7 @@ def patch_user(username: str, user: UserUpdate, response: Response):
     response.headers['Location'] = f'{API_URL}/users/{user.username}'
     return user
 
-@router.patch('/groups/{groupname}', tags=['groups'], status_code=201, response_model=Group, responses={**e409_response})
+@router.patch('/groups/{groupname}', tags=['groups'], status_code=200, response_model=Group, responses={**e409_response})
 def patch_group(groupname: str, group: GroupUpdate, response: Response):
     if not group_repo.exists(groupname):
         raise HTTPException(404, 'Given group does not exist')

--- a/src/api.py
+++ b/src/api.py
@@ -115,6 +115,33 @@ def post_group(group: Group, response: Response):
     response.headers['Location'] = f'{API_URL}/groups/{group.groupname}'
     return group
 
+@router.put('/nas/{nasname}', tags=['nas'], status_code=201, response_model=Nas, responses={**e409_response})
+def put_nas(nasname: str, nas: Nas, response: Response):
+    if not nas_repo.exists(nasname):
+        raise HTTPException(404, 'Given NAS does not exist')
+
+    nas_repo.update(nasname, nas)
+    response.headers['Location'] = f'{API_URL}/nas/{nas.nasname}'
+    return nas
+
+@router.put('/users/{username}', tags=['users'], status_code=201, response_model=User, responses={**e409_response})
+def put_user(username: str, user: User, response: Response):
+    if not user_repo.exists(username):
+        raise HTTPException(404, detail='Given user does not exist')
+
+    user_repo.update(username, user)
+    response.headers['Location'] = f'{API_URL}/users/{user.username}'
+    return user
+
+@router.put('/groups/{groupname}', tags=['groups'], status_code=201, response_model=Group, responses={**e409_response})
+def put_group(groupname: str, group: Group, response: Response):
+    if not group_repo.exists(groupname):
+        raise HTTPException(404, 'Given group does not exist')
+
+    group_repo.update(groupname, group)
+    response.headers['Location'] = f'{API_URL}/groups/{group.groupname}'
+    return group
+
 @router.delete('/nas/{nasname}', tags=['nas'], status_code=204, responses={**e404_response})
 def delete_nas(nasname: str):
     if not nas_repo.exists(nasname):

--- a/src/pyfreeradius.py
+++ b/src/pyfreeradius.py
@@ -241,6 +241,23 @@ class UserRepository(BaseRepository):
                 sql = f'INSERT INTO {self.radusergroup} (username, groupname, priority) VALUES (%s, %s, %s)'
                 db_cursor.execute(sql, (user.username, group.groupname, group.priority))
 
+    def update(self, username: str, user: User):
+        with self._db_cursor() as db_cursor:
+            db_cursor.execute(f'DELETE FROM {self.radcheck} WHERE username = %s', (username, ))
+            for check in user.checks:
+                sql = f'INSERT INTO {self.radcheck} (username, attribute, op, value) VALUES (%s, %s, %s, %s)'
+                db_cursor.execute(sql, (username, check.attribute, check.op, check.value))
+
+            db_cursor.execute(f'DELETE FROM {self.radreply} WHERE username = %s', (username, ))
+            for reply in user.replies:
+                sql = f'INSERT INTO {self.radreply} (username, attribute, op, value) VALUES (%s, %s, %s, %s)'
+                db_cursor.execute(sql, (username, reply.attribute, reply.op, reply.value))
+
+            db_cursor.execute(f'DELETE FROM {self.radusergroup} WHERE username = %s', (username, ))
+            for group in user.groups:
+                sql = f'INSERT INTO {self.radusergroup} (username, groupname, priority) VALUES (%s, %s, %s)'
+                db_cursor.execute(sql, (username, group.groupname, group.priority))
+
     def remove(self, username: str):
         with self._db_cursor() as db_cursor:
             db_cursor.execute(f'DELETE FROM {self.radcheck} WHERE username = %s', (username, ))
@@ -340,7 +357,24 @@ class GroupRepository(BaseRepository):
                 sql = f'INSERT INTO {self.radusergroup} (groupname, username, priority) VALUES (%s, %s, %s)'
                 db_cursor.execute(sql, (group.groupname, user.username, user.priority))
 
-    def remove(self, groupname: str) -> bool:
+    def update(self, groupname: str, group: Group):
+        with self._db_cursor() as db_cursor:
+            db_cursor.execute(f'DELETE FROM {self.radgroupcheck} WHERE groupname = %s', (groupname, ))
+            for check in group.checks:
+                sql = f'INSERT INTO {self.radgroupcheck} (groupname, attribute, op, value) VALUES (%s, %s, %s, %s)'
+                db_cursor.execute(sql, (groupname, check.attribute, check.op, check.value))
+
+            db_cursor.execute(f'DELETE FROM {self.radgroupreply} WHERE groupname = %s', (groupname, ))
+            for reply in group.replies:
+                sql = f'INSERT INTO {self.radgroupreply} (groupname, attribute, op, value) VALUES (%s, %s, %s, %s)'
+                db_cursor.execute(sql, (groupname, reply.attribute, reply.op, reply.value))
+
+            db_cursor.execute(f'DELETE FROM {self.radusergroup} WHERE groupname = %s', (groupname, ))
+            for user in group.users:
+                sql = f'INSERT INTO {self.radusergroup} (groupname, username, priority) VALUES (%s, %s, %s)'
+                db_cursor.execute(sql, (groupname, user.username, user.priority))
+
+    def remove(self, groupname: str):
         with self._db_cursor() as db_cursor:
             db_cursor.execute(f'DELETE FROM {self.radgroupcheck} WHERE groupname = %s', (groupname, ))
             db_cursor.execute(f'DELETE FROM {self.radgroupreply} WHERE groupname = %s', (groupname, ))
@@ -399,6 +433,13 @@ class NasRepository(BaseRepository):
         with self._db_cursor() as db_cursor:
             sql = f'INSERT INTO {self.nas} (nasname, shortname, secret) VALUES (%s, %s, %s)'
             db_cursor.execute(sql, (str(nas.nasname), nas.shortname, nas.secret))
+            self.db_connection.commit()
+
+    def update(self, nasname: IPvAnyAddress, nas: Nas):
+        with self._db_cursor() as db_cursor:
+            db_cursor.execute(f'DELETE FROM {self.nas} WHERE nasname = %s', (str(nasname), ))
+            sql = f'INSERT INTO {self.nas} (nasname, shortname, secret) VALUES (%s, %s, %s)'
+            db_cursor.execute(sql, (str(nasname), nas.shortname, nas.secret))
             self.db_connection.commit()
 
     def remove(self, nasname: IPvAnyAddress):

--- a/src/pyfreeradius.py
+++ b/src/pyfreeradius.py
@@ -150,8 +150,8 @@ class GroupUpdate(BaseModel):
         replies = self.replies
         users = self.users
 
-        if not (checks or replies):
-            raise ValueError('Group must have at least one check or one reply attribute')
+        if not (checks or replies or users):
+            raise ValueError('Group must have at least one check, one reply attribute or one group attribute')
 
         if users:
             usernames = [user.username for user in users]

--- a/src/pyfreeradius.py
+++ b/src/pyfreeradius.py
@@ -77,9 +77,8 @@ class UserUpdate(BaseModel):
         replies = self.replies
         groups = self.groups
 
-        if not (checks or replies or groups):
-            raise ValueError('User must have at least one check or one reply attribute'
-                             ', or must have at least one group')
+        if checks is None and replies is None and groups is None:
+            raise ValueError('Request must have at least one check, one reply attribute or one group')
 
         if groups:
             groupnames = [group.groupname for group in groups]
@@ -150,8 +149,8 @@ class GroupUpdate(BaseModel):
         replies = self.replies
         users = self.users
 
-        if not (checks or replies or users):
-            raise ValueError('Group must have at least one check, one reply attribute or one group attribute')
+        if checks is None and replies is None and users is None:
+            raise ValueError('Request must have at least one check, one reply attribute or one group')
 
         if users:
             usernames = [user.username for user in users]

--- a/src/test.py
+++ b/src/test.py
@@ -1,6 +1,6 @@
 from database import db_connection, db_tables
 from pydantic import ValidationError
-from pyfreeradius import User, Group, Nas, AttributeOpValue, UserGroup, GroupUser
+from pyfreeradius import User, Group, Nas, AttributeOpValue, UserGroup, GroupUser, UserUpdate, GroupUpdate, NasUpdate
 from pyfreeradius import UserRepository, GroupRepository, NasRepository
 import unittest
 
@@ -28,7 +28,6 @@ class TestModelsAndRepositories(unittest.TestCase):
 
         # Model: valid instance
         u = User(username='u', checks=checks, replies=replies)
-        u2 = User(username='u', checks=checks2, replies=replies2)
 
         # Repository: adding
         self.assertFalse(user_repo.exists(u.username))
@@ -42,8 +41,15 @@ class TestModelsAndRepositories(unittest.TestCase):
         self.assertIn(u.username, user_repo.find_usernames(from_username='t'))
 
         # Repository: updating
-        user_repo.update(u.username, u2)
-        self.assertEqual(user_repo.find_one(u.username), u2)
+        user_repo.update(u.username, UserUpdate(checks=checks2))
+        db_u = user_repo.find_one(u.username)
+        self.assertEqual(db_u.checks, checks2)
+        self.assertEqual(db_u.replies, replies)
+
+        user_repo.update(u.username, UserUpdate(replies=replies2))
+        db_u = user_repo.find_one(u.username)
+        self.assertEqual(db_u.checks, checks2)
+        self.assertEqual(db_u.replies, replies2)
 
         # Repository: removing
         user_repo.remove(u.username)
@@ -62,7 +68,6 @@ class TestModelsAndRepositories(unittest.TestCase):
 
         # Model: valid instance
         g = Group(groupname='g', checks=checks, replies=replies)
-        g2 = Group(groupname='g', checks=checks2, replies=replies2)
 
         # Repository: adding
         self.assertFalse(group_repo.exists(g.groupname))
@@ -76,8 +81,15 @@ class TestModelsAndRepositories(unittest.TestCase):
         self.assertIn(g.groupname, group_repo.find_groupnames(from_groupname='f'))
 
         # Repository: updating
-        group_repo.update(g.groupname, g2)
-        self.assertEqual(group_repo.find_one(g.groupname), g2)
+        group_repo.update(g.groupname, GroupUpdate(checks=checks2))
+        db_g = group_repo.find_one(g.groupname)
+        self.assertEqual(db_g.checks, checks2)
+        self.assertEqual(db_g.replies, replies)
+
+        group_repo.update(g.groupname, GroupUpdate(replies=replies2))
+        db_g = group_repo.find_one(g.groupname)
+        self.assertEqual(db_g.checks, checks2)
+        self.assertEqual(db_g.replies, replies2)
 
         # Repository: removing
         group_repo.remove(g.groupname)
@@ -90,7 +102,6 @@ class TestModelsAndRepositories(unittest.TestCase):
 
         # Model: valid instance
         n = Nas(nasname='1.1.1.1', shortname='sh', secret='se')
-        n2 = Nas(nasname='1.1.1.1', shortname='sh2', secret='se2')
 
         # Repository: adding
         self.assertFalse(nas_repo.exists(n.nasname))
@@ -104,8 +115,15 @@ class TestModelsAndRepositories(unittest.TestCase):
         self.assertIn(str(n.nasname), nas_repo.find_nasnames(from_nasname='1.1.1.0'))
 
         # Repository: updating
-        nas_repo.update(n.nasname, n2)
-        self.assertEqual(nas_repo.find_one(n.nasname), n2)
+        nas_repo.update(n.nasname, NasUpdate(shortname='sh2'))
+        db_n = nas_repo.find_one(n.nasname)
+        self.assertEqual(db_n.shortname, 'sh2')
+        self.assertEqual(db_n.secret, 'se')
+
+        nas_repo.update(n.nasname, NasUpdate(secret='se2'))
+        db_n = nas_repo.find_one(n.nasname)
+        self.assertEqual(db_n.shortname, 'sh2')
+        self.assertEqual(db_n.secret, 'se2')
 
         # Repository: removing
         nas_repo.remove(n.nasname)

--- a/src/test.py
+++ b/src/test.py
@@ -51,6 +51,9 @@ class TestModelsAndRepositories(unittest.TestCase):
         self.assertEqual(db_u.checks, checks2)
         self.assertEqual(db_u.replies, replies2)
 
+        # with self.assertRaises(HTTPException):
+        #     user_repo.update(u.username, UserUpdate(checks=[], replies=[], groups=[]))
+
         # Repository: removing
         user_repo.remove(u.username)
         self.assertFalse(user_repo.exists(u.username))
@@ -90,6 +93,9 @@ class TestModelsAndRepositories(unittest.TestCase):
         db_g = group_repo.find_one(g.groupname)
         self.assertEqual(db_g.checks, checks2)
         self.assertEqual(db_g.replies, replies2)
+
+        # with self.assertRaises(HTTPException):
+        #     group_repo.update(g.groupname, GroupUpdate(checks=[], replies=[]))
 
         # Repository: removing
         group_repo.remove(g.groupname)

--- a/src/test.py
+++ b/src/test.py
@@ -11,7 +11,9 @@ nas_repo = NasRepository(db_connection, db_tables)
 
 # Some dumb attributes for the tests
 checks = [AttributeOpValue(attribute='a', op=':=', value='b')]
+checks2 = [AttributeOpValue(attribute='a', op=':=', value='b2')]
 replies = [AttributeOpValue(attribute='c', op=':=', value='d')]
+replies2 = [AttributeOpValue(attribute='c', op=':=', value='d2')]
 
 class TestModelsAndRepositories(unittest.TestCase):
     def test_user(self):
@@ -26,6 +28,7 @@ class TestModelsAndRepositories(unittest.TestCase):
 
         # Model: valid instance
         u = User(username='u', checks=checks, replies=replies)
+        u2 = User(username='u', checks=checks2, replies=replies2)
 
         # Repository: adding
         self.assertFalse(user_repo.exists(u.username))
@@ -37,6 +40,10 @@ class TestModelsAndRepositories(unittest.TestCase):
         self.assertIn(u.username, user_repo.find_all_usernames())
         self.assertIn(u.username, user_repo.find_usernames())
         self.assertIn(u.username, user_repo.find_usernames(from_username='t'))
+
+        # Repository: updating
+        user_repo.update(u.username, u2)
+        self.assertEqual(user_repo.find_one(u.username), u2)
 
         # Repository: removing
         user_repo.remove(u.username)
@@ -55,6 +62,7 @@ class TestModelsAndRepositories(unittest.TestCase):
 
         # Model: valid instance
         g = Group(groupname='g', checks=checks, replies=replies)
+        g2 = Group(groupname='g', checks=checks2, replies=replies2)
 
         # Repository: adding
         self.assertFalse(group_repo.exists(g.groupname))
@@ -67,6 +75,10 @@ class TestModelsAndRepositories(unittest.TestCase):
         self.assertIn(g.groupname, group_repo.find_groupnames())
         self.assertIn(g.groupname, group_repo.find_groupnames(from_groupname='f'))
 
+        # Repository: updating
+        group_repo.update(g.groupname, g2)
+        self.assertEqual(group_repo.find_one(g.groupname), g2)
+
         # Repository: removing
         group_repo.remove(g.groupname)
         self.assertFalse(group_repo.exists(g.groupname))
@@ -78,6 +90,7 @@ class TestModelsAndRepositories(unittest.TestCase):
 
         # Model: valid instance
         n = Nas(nasname='1.1.1.1', shortname='sh', secret='se')
+        n2 = Nas(nasname='1.1.1.1', shortname='sh2', secret='se2')
 
         # Repository: adding
         self.assertFalse(nas_repo.exists(n.nasname))
@@ -89,6 +102,10 @@ class TestModelsAndRepositories(unittest.TestCase):
         self.assertIn(str(n.nasname), nas_repo.find_all_nasnames())
         self.assertIn(str(n.nasname), nas_repo.find_nasnames())
         self.assertIn(str(n.nasname), nas_repo.find_nasnames(from_nasname='1.1.1.0'))
+
+        # Repository: updating
+        nas_repo.update(n.nasname, n2)
+        self.assertEqual(nas_repo.find_one(n.nasname), n2)
 
         # Repository: removing
         nas_repo.remove(n.nasname)


### PR DESCRIPTION
~This PR adds support for PUT requests to fully replace an entity in one transaction. Note that you'll need to supply the full object. Non-supplied checks or linked users for example will be removed.~

This PR adds support for PATCH requests to partially replace an entity in one transaction. You'll need to pass the properties you want to replace. If you want to replace the full object, specify all properties.

See https://github.com/angely-dev/freeradius-api/issues/5