### PR TITLE
Remove double commit() from NasRepository.add()

### DIFF
--- a/src/pyfreeradius.py
+++ b/src/pyfreeradius.py
@@ -399,7 +399,6 @@ class NasRepository(BaseRepository):
         with self._db_cursor() as db_cursor:
             sql = f'INSERT INTO {self.nas} (nasname, shortname, secret) VALUES (%s, %s, %s)'
             db_cursor.execute(sql, (str(nas.nasname), nas.shortname, nas.secret))
-            self.db_connection.commit()
 
     def remove(self, nasname: IPvAnyAddress):
         with self._db_cursor() as db_cursor:


### PR DESCRIPTION
It seems that there was still a `self.db_connection.commit()` in the `NasRepository.add()` method. 

The `commit()` is already done in the finally block of the `_db_cursor()` method.